### PR TITLE
Bugfix when dumping just headers without a summary

### DIFF
--- a/src/todump.cc
+++ b/src/todump.cc
@@ -221,8 +221,9 @@ ToDump::write_packet(Packet *p)
     ph.caplen = to_write;
 
     // XXX writing to pipe?
-    if (fwrite(&ph, sizeof(ph), 1, _fp) == 0
-	|| fwrite(p->data(), 1, to_write, _fp) == 0) {
+    std::size_t ph_size = sizeof(ph);
+    if ( (fwrite(&ph, ph_size, 1, _fp) == 0 && ph_size > 0)
+	|| (fwrite(p->data(), 1, to_write, _fp) == 0 && to_write > 0) ) {
 	if (errno != EAGAIN) {
 	    _active = false;
 	    click_chatter("ToDump(%s): %s", _filename.c_str(), strerror(errno));


### PR DESCRIPTION
This fixes a bug we ran into while using ipsumdump. Thanks for maintaining this!
