### PR TITLE
[FIX] 'SIOCGSTAMP' was not declared in this scope

### DIFF
--- a/libclick-2.1/include/click/etheraddress.hh
+++ b/libclick-2.1/include/click/etheraddress.hh
@@ -4,6 +4,13 @@
 #include <click/string.hh>
 #include <click/glue.hh>
 #include <click/type_traits.hh>
+#ifndef SIOCGSTAMP
+#ifdef SIOCGSTAMP_OLD
+#define SIOCGSTAMP SIOCGSTAMP_OLD
+#else
+#include <linux/sockios.h>
+#endif
+#endif
 CLICK_DECLS
 
 class EtherAddress { public:


### PR DESCRIPTION
https://wiki.gentoo.org/wiki/Linux_headers_5.2_porting_notes/SIOCGSTAMP