### PR TITLE
ipsumdump: add linux header

### DIFF
--- a/src/fromdevice.hh
+++ b/src/fromdevice.hh
@@ -5,6 +5,7 @@
 
 #ifdef __linux__
 # define FROMDEVICE_ALLOW_LINUX 1
+#include <linux/sockios.h>
 #endif
 
 #if HAVE_PCAP


### PR DESCRIPTION
src: https://patchwork.kernel.org/project/qemu-devel/patch/20190617114005.24603-1-berrange@redhat.com/#22706197

Tested:

Before:
```
$ make
...
  722 |     struct AllAnno {
      |            ^~~~~~~
In file included from fromdevice.cc:36:
../libclick-2.1/include/click/etheraddress.hh: In member function 'const uint16_t* EtherAddress::sdata() const':
../libclick-2.1/include/click/etheraddress.hh:90:16: warning: taking address of packed member of 'EtherAddress' may result in an unaligned pointer value [-Waddress-of-packed-member]
   90 |         return _data;
      |                ^~~~~
fromdevice.cc: In member function 'virtual void FromDevice::selected(int, int)':
fromdevice.cc:546:56: error: 'SIOCGSTAMP' was not declared in this scope; did you mean 'SIOCGRARP'?
  546 |             p->timestamp_anno().set_timeval_ioctl(_fd, SIOCGSTAMP);
      |                                                        ^~~~~~~~~~
      |                                                        SIOCGRARP
make[1]: *** [Makefile:46: fromdevice.o] Error 1
make[1]: Leaving directory 'ipsumdump/src'
make: *** [Makefile:40: src] Error 2
```

After:
```
$ make
...
$ echo $?
0
```